### PR TITLE
Minor cleanup for mips-tdep.c

### DIFF
--- a/gdb/mips-tdep.c
+++ b/gdb/mips-tdep.c
@@ -296,7 +296,7 @@ mips_simple_cheri_register_p (struct gdbarch *gdbarch, int regnum)
   int cap0 = mips_regnum (gdbarch)->cap0;
 
   return (cap0 != -1
-	  && rawnum >= cap0 && rawnum <= mips_regnum (gdbarch)->cap_pcc);
+	  && rawnum >= cap0 && rawnum < mips_regnum (gdbarch)->cap_cause);
 }
 
 #define MIPS_EABI(gdbarch) (gdbarch_tdep (gdbarch)->mips_abi \
@@ -642,13 +642,14 @@ static const char *mips_generic_reg_names[NUM_MIPS_PROCESSOR_REGS] = {
 
 /* CHERI Capabilities.  */
 
-static const char *mips_cheri_reg_names[36] = {
+static const char *mips_cheri_reg_names[] = {
   "c0", "c1", "c2", "c3", "c4", "c5", "c6", "c7",
   "c8", "c9", "c10", "c11", "c12", "c13", "c14", "c15",
   "c16", "c17", "c18", "c19", "c20", "c21", "c22", "c23",
   "c24", "c25", "c26", "c27", "c28", "c29", "c30", "c31",
   "ddc", "pcc", "cap_cause", "cap_valid",
 };
+_Static_assert(ARRAY_SIZE (mips_cheri_reg_names) == 36, "");
 
 /* Names of tx39 registers.  */
 
@@ -9426,7 +9427,7 @@ mips_gdbarch_init (struct gdbarch_info info, struct gdbarch_list *arches)
 	      mips_regnum.cap0 = cap0;
 	      mips_regnum.cap_ddc = cap0 + 32;
 	      mips_regnum.cap_pcc = cap0 + 33;
-	      mips_regnum.cap_cause = cap0 + 34;
+	      mips_regnum.cap_cause = cap0 + ARRAY_SIZE (mips_cheri_reg_names) - 2;
 
 	      num_regs = mips_regnum.cap_cause + 2;
 	    }
@@ -9445,7 +9446,7 @@ mips_gdbarch_init (struct gdbarch_info info, struct gdbarch_list *arches)
       mips_regnum.cap0 = cap0;
       mips_regnum.cap_ddc = cap0 + 32;
       mips_regnum.cap_pcc = cap0 + 33;
-      mips_regnum.cap_cause = cap0 + 34;
+      mips_regnum.cap_cause = cap0 + ARRAY_SIZE (mips_cheri_reg_names) - 2;
 
       num_regs = mips_regnum.cap_cause + 2;
     }

--- a/gdb/mips-tdep.c
+++ b/gdb/mips-tdep.c
@@ -9336,78 +9336,9 @@ mips_gdbarch_init (struct gdbarch_info info, struct gdbarch_list *arches)
 	    {
 	      i = 0;
 	      valid_p = 1;
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c0");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c1");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c2");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c3");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c4");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c5");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c6");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c7");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c8");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c9");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c10");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c11");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c12");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c13");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c14");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c15");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c16");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c17");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c18");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c19");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c20");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c21");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c22");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c23");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c24");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c25");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c26");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c27");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c28");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c29");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c30");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "c31");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "ddc");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "pcc");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "cap_cause");
-	      valid_p &= tdesc_numbered_register (feature, tdesc_data,
-						  cap0 + i++, "cap_valid");
+	      for (i = 0; i < ARRAY_SIZE (mips_cheri_reg_names); i++)
+		valid_p &= tdesc_numbered_register (feature, tdesc_data, cap0 + i,
+						    mips_cheri_reg_names[i]);
 
 	      if (valid_p)
 		{


### PR DESCRIPTION
I initially thought I had to update the XML files to add the new
registers that QEMU exposes to fix https://github.com/CTSRD-CHERI/gdb/issues/34,
but it turns out that the cause was just an off-by-one in QEMU (https://github.com/CTSRD-CHERI/qemu/commit/a04986ea0a6ad382bdfb9ac217dd652a9fe83f5a).

This PR now has the other minor cleanups that I made while debugging that issue.
