### PR TITLE
Mode-dependent RISC-V disassembly

### DIFF
--- a/bfd/elfxx-riscv.c
+++ b/bfd/elfxx-riscv.c
@@ -855,6 +855,16 @@ static reloc_howto_type howto_table[] =
 	 0,				/* src_mask */
 	 MINUS_ONE,			/* dst_mask */
 	 FALSE),			/* pcrel_offset */
+
+    /* Avoid crashing when we see CHERI relocations */
+    /* See llvm/include/llvm/BinaryFormat/ELFRelocs/RISCV.def */
+    [192] = EMPTY_HOWTO(192/* R_RISCV_CHERI_CAPTAB_PCREL_HI20 */),
+    [193] = EMPTY_HOWTO(193/* R_RISCV_CHERI_CAPABILITY */),
+    [194] = EMPTY_HOWTO(194/* R_RISCV_CHERI_CAPABILITY_CALL */),
+    [195] = EMPTY_HOWTO(195/* R_RISCV_CHERI_SIZE */),
+    [196] = EMPTY_HOWTO(196/* R_RISCV_CHERI_TPREL_CINCOFFSET */),
+    [197] = EMPTY_HOWTO(197/* R_RISCV_CHERI_TLS_IE_CAPTAB_PCREL_HI20 */),
+    [198] = EMPTY_HOWTO(198/* R_RISCV_CHERI_TLS_GD_CAPTAB_PCREL_HI20 */),
 };
 
 /* A mapping from BFD reloc types to RISC-V ELF reloc types.  */

--- a/include/opcode/riscv.h
+++ b/include/opcode/riscv.h
@@ -27,6 +27,9 @@
 
 typedef uint64_t insn_t;
 
+#define RISCV_OPCODE_FLAG_CAPMODE_ENABLED 0x1
+#define RISCV_OPCODE_FLAG_CAPMODE_DISABLED 0x2
+
 static inline unsigned int riscv_insn_length (insn_t insn)
 {
   if ((insn & 0x3) != 0x3) /* RVC.  */
@@ -366,6 +369,10 @@ struct riscv_opcode
 #define INSN_4_BYTE		0x00000030
 #define INSN_8_BYTE		0x00000040
 #define INSN_16_BYTE		0x00000050
+/* This instruction is only available in capability mode */
+#define INSN_CAPMODE		0x00000100
+/* This instruction is not available in capability mode */
+#define INSN_NOT_CAPMODE	0x00000200
 
 /* Instruction is actually a macro.  It should be ignored by the
    disassembler, and requires special treatment by the assembler.  */

--- a/opcodes/riscv-opc.c
+++ b/opcodes/riscv-opc.c
@@ -346,7 +346,8 @@ const struct riscv_opcode riscv_opcodes[] =
 {"or",          0, {"C", 0},   "Cs,Ct,Cw",  MATCH_C_OR, MASK_C_OR, match_opcode, INSN_ALIAS },
 {"or",          0, {"I", 0},   "d,s,t",  MATCH_OR, MASK_OR, match_opcode, 0 },
 {"or",          0, {"I", 0},   "d,s,j",  MATCH_ORI, MASK_ORI, match_opcode, INSN_ALIAS },
-{"auipc",       0, {"I", 0},   "d,u",  MATCH_AUIPC, MASK_AUIPC, match_opcode, 0 },
+{"auipc",       0, {"I", 0},   "d,u",  MATCH_AUIPC, MASK_AUIPC, match_opcode, INSN_NOT_CAPMODE },
+{"auipcc",      0, {"I", "Xcheri", 0}, "d,u",  MATCH_AUIPC, MASK_AUIPC, match_opcode, INSN_CAPMODE },
 {"seqz",        0, {"I", 0},   "d,s",  MATCH_SLTIU | ENCODE_ITYPE_IMM (1), MASK_SLTIU | MASK_IMM, match_opcode, INSN_ALIAS },
 {"snez",        0, {"I", 0},   "d,t",  MATCH_SLTU, MASK_SLTU | MASK_RS1, match_opcode, INSN_ALIAS },
 {"sltz",        0, {"I", 0},   "d,s",  MATCH_SLT, MASK_SLT | MASK_RS2, match_opcode, INSN_ALIAS },
@@ -928,11 +929,15 @@ const struct riscv_opcode riscv_opcodes[] =
 {"sc.c.cap",   32, {"Xcheri", 0}, "Xt,0(Xs)", MATCH_SC_D_CAP, MASK_SC_D_CAP, match_opcode, INSN_DREF|INSN_8_BYTE},
 {"sc.c.cap",   64, {"Xcheri", 0}, "Xt,0(Xs)", MATCH_SC_Q_CAP, MASK_SC_Q_CAP, match_opcode, INSN_DREF|INSN_16_BYTE},
 
-/* Memory-Access Instructions */  
-{"lc",         32, {"Xcheri", 0}, "Xd,o(s)", MATCH_LD, MASK_LD, match_opcode, INSN_DREF|INSN_8_BYTE},
-{"lc",         64, {"Xcheri", 0}, "Xd,o(s)", MATCH_LQ, MASK_LQ, match_opcode, INSN_DREF|INSN_16_BYTE},
-{"sc",         32, {"Xcheri", 0}, "Xt,q(s)", MATCH_SD, MASK_SD, match_opcode, INSN_DREF|INSN_8_BYTE},
-{"sc",         64, {"Xcheri", 0}, "Xt,q(s)", MATCH_SQ, MASK_SQ, match_opcode, INSN_DREF|INSN_16_BYTE},
+/* Memory-Access Instructions */
+{"clc",        32, {"Xcheri", 0}, "Xd,o(Xs)", MATCH_LD, MASK_LD, match_opcode, INSN_DREF|INSN_8_BYTE|INSN_CAPMODE},
+{"clc",        64, {"Xcheri", 0}, "Xd,o(Xs)", MATCH_LQ, MASK_LQ, match_opcode, INSN_DREF|INSN_16_BYTE|INSN_CAPMODE},
+{"csc",        32, {"Xcheri", 0}, "Xt,q(Xs)", MATCH_SD, MASK_SD, match_opcode, INSN_DREF|INSN_8_BYTE|INSN_CAPMODE},
+{"csc",        64, {"Xcheri", 0}, "Xt,q(Xs)", MATCH_SQ, MASK_SQ, match_opcode, INSN_DREF|INSN_16_BYTE|INSN_CAPMODE},
+{"lc",         32, {"Xcheri", 0}, "Xd,o(s)", MATCH_LD, MASK_LD, match_opcode, INSN_DREF|INSN_8_BYTE|INSN_NOT_CAPMODE},
+{"lc",         64, {"Xcheri", 0}, "Xd,o(s)", MATCH_LQ, MASK_LQ, match_opcode, INSN_DREF|INSN_16_BYTE|INSN_NOT_CAPMODE},
+{"sc",         32, {"Xcheri", 0}, "Xt,q(s)", MATCH_SD, MASK_SD, match_opcode, INSN_DREF|INSN_8_BYTE|INSN_NOT_CAPMODE},
+{"sc",         64, {"Xcheri", 0}, "Xt,q(s)", MATCH_SQ, MASK_SQ, match_opcode, INSN_DREF|INSN_16_BYTE|INSN_NOT_CAPMODE},
 
 /* Atomic Memory-Access Instructions */
 {"lr.b",        0, {"A", "Xcheri", 0}, "d,0(s)", MATCH_LR_B, MASK_LR_B | MASK_AQRL, match_opcode, INSN_DREF|INSN_1_BYTE},


### PR DESCRIPTION
Constantly reading the wrong instructions was sufficiently annoying so I tried to fix this. I'm not sure if this approach is the best way of doing this, but it appears to work.
If this seems okay I'll add support for the remaining mode-dependent instructions.

With this change mode-dependent instructions such as AUIPCC/CLC/etc. will
be disassembled as the capmode version.
In order to do determine the mode we are in right now we pass an additional
flag to the disassembler. If this flag is not passed (e.g. in the objdump
case), we fall back to querying the ELF header to check for EF_RISCV_CAPMODE.

Note: this is currently not quite correct for GDB: there is no cached value
for capmode so we use is_cheriabi instead (which is generally the same but
is not necessarily true).

TODO: A follow-up change should set the value of capmode based on PCC.flags
when the current PCC is available instead of statically based on the ELF
header of the main program.