### PR TITLE
Add a suffix when printing out-of-bounds capabilities

### DIFF
--- a/gdb/riscv-tdep.c
+++ b/gdb/riscv-tdep.c
@@ -3316,6 +3316,10 @@ riscv_cheri_print_pointer_attributes (struct gdbarch *gdbarch,
 		    cap.cr_otype == CC128_OTYPE_SENTRY
 		         ? " (sentry)"
 		         : (cc128_is_cap_sealed(&cap) ? " (sealed)" : ""));
+  /* Also highlight capabilities that are out-of-bounds to make invalid
+     values more obvious in backtraces. */
+  if (cap.address () < cap.base () || cap.address () >= cap.top ())
+    fprintf_filtered (stream, " (out-of-bounds)");
 }
 
 /* Initialize the current architecture based on INFO.  If possible,


### PR DESCRIPTION
This makes it a lot easier to determine whether a capability is
out-of-bounds, espeicially if the address look quite similar:

```
(gdb) p e
$1 = (FcPatternElt *) 0x42a58200 [rwRW,0x42a558c0-0x42a558f0] (out-of-bounds)
```