### PR TITLE
Don't let bison use color diagnostics.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -136,7 +136,7 @@ POSTSTAGE1_LIBS = @poststage1_libs@
 BASE_EXPORTS = \
 	FLEX="$(FLEX)"; export FLEX; \
 	LEX="$(LEX)"; export LEX; \
-	BISON="$(BISON)"; export BISON; \
+	BISON="$(BISON) --color=never"; export BISON; \
 	YACC="$(YACC)"; export YACC; \
 	M4="$(M4)"; export M4; \
 	SED="$(SED)"; export SED; \

--- a/binutils/Makefile.am
+++ b/binutils/Makefile.am
@@ -31,7 +31,7 @@ CC_FOR_BUILD = @CC_FOR_BUILD@
 EXEEXT_FOR_BUILD = @EXEEXT_FOR_BUILD@
 
 YACC = `if [ -f ../bison/bison ]; then echo ../bison/bison -y -L$(srcdir)/../bison/; else echo @YACC@; fi`
-YFLAGS = -d
+YFLAGS = -d --color=never
 LEX = `if [ -f ../flex/flex ]; then echo ../flex/flex; else echo @LEX@; fi`
 LEXLIB = @LEXLIB@
 

--- a/binutils/Makefile.in
+++ b/binutils/Makefile.in
@@ -490,7 +490,7 @@ WARN_CFLAGS_FOR_BUILD = @WARN_CFLAGS_FOR_BUILD@
 WARN_WRITE_STRINGS = @WARN_WRITE_STRINGS@
 XGETTEXT = @XGETTEXT@
 YACC = `if [ -f ../bison/bison ]; then echo ../bison/bison -y -L$(srcdir)/../bison/; else echo @YACC@; fi`
-YFLAGS = -d
+YFLAGS = -d --color=never
 abs_builddir = @abs_builddir@
 abs_srcdir = @abs_srcdir@
 abs_top_builddir = @abs_top_builddir@

--- a/gdb/Makefile.in
+++ b/gdb/Makefile.in
@@ -122,6 +122,7 @@ COMPILE = $(ECHO_CXX) $(COMPILE.pre) $(INTERNAL_CFLAGS) $(COMPILE.post)
 POSTCOMPILE = @true
 
 YACC = @YACC@
+YFLAGS = --color=never
 
 # This is used to rebuild ada-lex.c from ada-lex.l.  If the program is
 # not defined, but ada-lex.c is present, compilation will continue,


### PR DESCRIPTION
There seems to be a bug on FreeBSD where bison crashes with color
dignosics.

At least one change is redundant, but this should be a transient fix once https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=256731#c5 is fixed